### PR TITLE
DM velocity dispersion calculation should be correct now

### DIFF
--- a/src/feedback/EAGLE_kinetic/feedback_iact.h
+++ b/src/feedback/EAGLE_kinetic/feedback_iact.h
@@ -30,12 +30,10 @@
  *
  * @param si First sparticle.
  * @param gj Second particle (not updated).
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
-runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+runner_iact_nonsym_feedback_dm_vel_sum(struct spart *si, 
+                                        const struct gpart *gj) {
 
 }
 
@@ -44,12 +42,10 @@ runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si,
  *
  * @param si First sparticle.
  * @param gj Second particle.
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
 runner_iact_nonsym_feedback_dm_vel_disp(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+                                        const struct gpart *gj) {
  
 }
 

--- a/src/feedback/EAGLE_thermal/feedback_iact.h
+++ b/src/feedback/EAGLE_thermal/feedback_iact.h
@@ -30,12 +30,10 @@
  *
  * @param si First sparticle.
  * @param gj Second particle (not updated).
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
-runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+runner_iact_nonsym_feedback_dm_vel_sum(struct spart *si, 
+                                        const struct gpart *gj) {
 
 }
 
@@ -44,12 +42,10 @@ runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si,
  *
  * @param si First sparticle.
  * @param gj Second particle.
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
 runner_iact_nonsym_feedback_dm_vel_disp(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+                                        const struct gpart *gj) {
  
 }
 

--- a/src/feedback/GEAR/feedback_iact.h
+++ b/src/feedback/GEAR/feedback_iact.h
@@ -29,12 +29,10 @@
  *
  * @param si First sparticle.
  * @param gj Second particle (not updated).
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
-runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+runner_iact_nonsym_feedback_dm_vel_sum(struct spart *si, 
+                                        const struct gpart *gj) {
 
 }
 
@@ -43,12 +41,10 @@ runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si,
  *
  * @param si First sparticle.
  * @param gj Second particle.
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
 runner_iact_nonsym_feedback_dm_vel_disp(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+                                        const struct gpart *gj) {
  
 }
 

--- a/src/feedback/SIMBA/feedback.h
+++ b/src/feedback/SIMBA/feedback.h
@@ -99,11 +99,6 @@ __attribute__((always_inline)) INLINE static void feedback_init_spart(
   sp->feedback_data.to_collect.ngb_mass = 0.f;
   sp->feedback_data.to_collect.ngb_rho = 0.f;
   sp->feedback_data.to_collect.ngb_Z = 0.f;
-  sp->feedback_data.to_collect.dm_ngb_N = 0;
-  for (int i = 0; i < 3; i++) {
-    sp->feedback_data.to_collect.dm_vel_mean[i] = 0.f;
-    sp->feedback_data.to_collect.dm_vel_disp2[i] = 0.f;
-  }
 
   /* Reset all ray structs carried by this star particle */
   ray_init(sp->feedback_data.SNII_rays, eagle_SNII_feedback_num_of_rays);
@@ -173,7 +168,12 @@ __attribute__((always_inline)) INLINE static void feedback_reset_feedback(
   sp->feedback_data.to_distribute.SNII_num_of_thermal_energy_inj = 0;
 
   /* Zero the DM vel. disp. */
-  sp->feedback_data.to_distribute.dm_vel_disp_1d = 0.f;
+  sp->feedback_data.dm_vel_disp_1d = 0.f;
+  sp->feedback_data.dm_ngb_N = 0;
+  for (int i = 0; i < 3; i++) {
+    sp->feedback_data.dm_vel_sum[i] = 0.f;
+    sp->feedback_data.dm_vel_disp2[i] = 0.f;
+  }
 }
 
 /**
@@ -189,6 +189,14 @@ __attribute__((always_inline)) INLINE static void feedback_first_init_spart(
     struct spart* sp, const struct feedback_props* feedback_props) {
 
   feedback_init_spart(sp);
+
+  /* These will be reset in feedback_reset_feedback each timestep */
+  sp->feedback_data.dm_ngb_N = 0;
+  sp->feedback_data.dm_vel_disp_1d = 0.f;
+  for (int i = 0; i < 3; i++) {
+    sp->feedback_data.dm_vel_sum[i] = 0.f;
+    sp->feedback_data.dm_vel_disp2[i] = 0.f;
+  }
 }
 
 /**

--- a/src/feedback/SIMBA/feedback_iact.h
+++ b/src/feedback/SIMBA/feedback_iact.h
@@ -31,18 +31,16 @@
  *
  * @param si First sparticle.
  * @param gj Second particle (not updated).
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
-runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+runner_iact_nonsym_feedback_dm_vel_sum(struct spart *si, 
+                                        const struct gpart *gj) {
   /* Get the DM mean velocity properties and save them. */
-  for (int vjd = 0; vjd < 3; vjd++) {
-    si->feedback_data.to_collect.dm_vel_mean[vjd] += gj->v_full[vjd];
+  for (int k = 0; k < 3; k++) {
+    si->feedback_data.dm_vel_sum[k] += gj->v_full[k];
   }
 
-  si->feedback_data.to_collect.dm_ngb_N++;
+  si->feedback_data.dm_ngb_N++;
 }
 
 /**
@@ -50,20 +48,19 @@ runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si,
  *
  * @param si First sparticle.
  * @param gj Second particle.
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
 runner_iact_nonsym_feedback_dm_vel_disp(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+                                        const struct gpart *gj) {
   /* Get the DM velocity dispersion. */
-
+  float v_mean_k = 0.f;
+  float vj_diff = 0.f;
   /* TODO: dm_vel_disp[3] is unnecessary to have in the structure, but leaving for now. */
-  for (int vjd = 0; vjd < 3; vjd++) {
+  for (int k = 0; k < 3; k++) {
     /* The real mean is divided by the total neighbours */
-    si->feedback_data.to_collect.dm_vel_mean[vjd] /= si->feedback_data.to_collect.dm_ngb_N;
-    float vj_diff = si->feedback_data.to_collect.dm_vel_mean[vjd] - gj->v_full[vjd];
-    si->feedback_data.to_collect.dm_vel_disp2[vjd] += vj_diff * vj_diff;
+    v_mean_k = si->feedback_data.dm_vel_sum[k] / (float)si->feedback_data.dm_ngb_N;
+    vj_diff = gj->v_full[k] - v_mean_k;
+    si->feedback_data.dm_vel_disp2[k] += vj_diff * vj_diff;
   }
 }
 

--- a/src/feedback/SIMBA/feedback_struct.h
+++ b/src/feedback/SIMBA/feedback_struct.h
@@ -66,15 +66,6 @@ struct feedback_spart_data {
 
       /*! Total (unweighted) number gas neighbours in the stellar kernel */
       int ngb_N;
-
-      /*! Mean neighbourhood DM velocity in each direction */
-      float dm_vel_mean[3];
-
-      /*! Number of dark matter neighbours in the (gas) neighbourhood */
-      int dm_ngb_N;
-
-      /*! DM velocity dispersion in each direction */
-      float dm_vel_disp2[3];
       
     } to_collect;
 
@@ -127,14 +118,23 @@ struct feedback_spart_data {
       /*! Change in energy from SNII feedback energy injection */
       float SNII_delta_u;
 
-      /*! DM 1D vel. disp. from Vogelsberger et al (2013) equation 14. */
-      float dm_vel_disp_1d;
-
     } to_distribute;
   };
 
   /* Instantiate ray structs for SNII isotropic feedback  */
   struct ray_data SNII_rays[eagle_SNII_feedback_num_of_rays];
+
+  /*! Mean neighbourhood DM velocity in each direction */
+  float dm_vel_sum[3];
+
+  /*! Number of dark matter neighbours in the (gas) neighbourhood */
+  int dm_ngb_N;
+
+  /*! DM velocity dispersion in each direction */
+  float dm_vel_disp2[3];
+
+  /*! DM 1D vel. disp. from Vogelsberger et al (2013) equation 14. */
+  float dm_vel_disp_1d;
 };
 
 #endif /* SWIFT_FEEDBACK_STRUCT_SIMBA_H */

--- a/src/feedback/none/feedback_iact.h
+++ b/src/feedback/none/feedback_iact.h
@@ -24,12 +24,10 @@
  *
  * @param si First sparticle.
  * @param gj Second particle (not updated).
- * @param fb_props Properties of the feedback scheme.
  */
 __attribute__((always_inline)) INLINE static void
-runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+runner_iact_nonsym_feedback_dm_vel_sum(struct spart *si, 
+                                        const struct gpart *gj) {
 
 }
 
@@ -42,8 +40,7 @@ runner_iact_nonsym_feedback_dm_vel_mean(struct spart *si,
  */
 __attribute__((always_inline)) INLINE static void
 runner_iact_nonsym_feedback_dm_vel_disp(struct spart *si, 
-                                        const struct gpart *gj,
-                                        const struct feedback_props *fb_props) {
+                                        const struct gpart *gj) {
  
 }
 

--- a/src/runner_doiact_functions_stars.h
+++ b/src/runner_doiact_functions_stars.h
@@ -66,10 +66,14 @@ void DOSELF1_STARS(struct runner *r, struct cell *c, int timer) {
 
   const int scount = c->stars.count;
   const int count = c->hydro.count;
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
   const int gcount = c->grav.count;
+#endif
   struct spart *restrict sparts = c->stars.parts;
   struct part *restrict parts = c->hydro.parts;
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
   struct gpart *restrict gparts = c->grav.parts;
+#endif
 #if (FUNCTION_TASK_LOOP == TASK_LOOP_FEEDBACK)
   struct xpart *restrict xparts = c->hydro.xparts;
 #endif
@@ -99,6 +103,7 @@ void DOSELF1_STARS(struct runner *r, struct cell *c, int timer) {
                           (float)(si->x[1] - c->loc[1]),
                           (float)(si->x[2] - c->loc[2])};
 
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
     /* Only do DM vel. disp. loop if necessary for the model. */
     int si_active_dm_loop = stars_dm_loop_is_active(si, e);
     if (si_active_dm_loop) {
@@ -112,9 +117,7 @@ void DOSELF1_STARS(struct runner *r, struct cell *c, int timer) {
           float dx[3] = {six[0] - gjx[0], six[1] - gjx[1], six[2] - gjx[2]};
           const float r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
           if (r2 < hig2) {
-#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
-            runner_iact_nonsym_feedback_dm_vel_mean(si, gj, e->feedback_props);
-#endif
+            runner_iact_nonsym_feedback_dm_vel_sum(si, gj);
           }
         }
       }
@@ -129,13 +132,12 @@ void DOSELF1_STARS(struct runner *r, struct cell *c, int timer) {
           float dx[3] = {six[0] - gjx[0], six[1] - gjx[1], six[2] - gjx[2]};
           const float r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
           if (r2 < hig2) {
-#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
-            runner_iact_nonsym_feedback_dm_vel_disp(si, gj, e->feedback_props);
-#endif
+            runner_iact_nonsym_feedback_dm_vel_disp(si, gj);
           }
         }
       }
     }
+#endif
 
     /* Loop over the parts in cj. */
     for (int pjd = 0; pjd < count; pjd++) {
@@ -388,10 +390,14 @@ void DO_SYM_PAIR1_STARS(struct runner *r, struct cell *ci, struct cell *cj,
     const double hi_max = ci->stars.h_max * kernel_gamma - rshift;
     const int count_i = ci->stars.count;
     const int count_j = cj->hydro.count;
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
     const int gcount_j = cj->grav.count;
+#endif
     struct spart *restrict sparts_i = ci->stars.parts;
     struct part *restrict parts_j = cj->hydro.parts;
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
     struct gpart *restrict gparts_j = cj->grav.parts;
+#endif
 #if (FUNCTION_TASK_LOOP == TASK_LOOP_FEEDBACK)
     struct xpart *restrict xparts_j = cj->hydro.xparts;
 #endif
@@ -432,6 +438,7 @@ void DO_SYM_PAIR1_STARS(struct runner *r, struct cell *ci, struct cell *cj,
       const float piy = spi->x[1] - (cj->loc[1] + shift[1]);
       const float piz = spi->x[2] - (cj->loc[2] + shift[2]);
 
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
       /* Only do DM vel. disp. loop if necessary for the model. */
       int si_active_dm_loop = stars_dm_loop_is_active(spi, e);
       if (si_active_dm_loop) {
@@ -446,9 +453,7 @@ void DO_SYM_PAIR1_STARS(struct runner *r, struct cell *ci, struct cell *cj,
             float dx[3] = {pix - gjx, piy - gjy, piz - gjz};
             const float r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
             if (r2 < hig2) {
-  #if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
-              runner_iact_nonsym_feedback_dm_vel_mean(spi, gj, e->feedback_props);
-  #endif
+              runner_iact_nonsym_feedback_dm_vel_sum(spi, gj);
             }
           }
         }
@@ -463,13 +468,12 @@ void DO_SYM_PAIR1_STARS(struct runner *r, struct cell *ci, struct cell *cj,
             float dx[3] = {pix - gjx, piy - gjy, piz - gjz};
             const float r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
             if (r2 < hig2) {
-  #if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
-              runner_iact_nonsym_feedback_dm_vel_disp(spi, gj, e->feedback_props);
-  #endif
+              runner_iact_nonsym_feedback_dm_vel_disp(spi, gj);
             }
           }
         }
       }
+#endif
 
       /* Loop over the parts in cj. */
       for (int pjd = 0; pjd < count_j && sort_j[pjd].d < di; pjd++) {
@@ -582,10 +586,14 @@ void DO_SYM_PAIR1_STARS(struct runner *r, struct cell *ci, struct cell *cj,
     const double hj_max = cj->stars.h_max * kernel_gamma;
     const int count_i = ci->hydro.count;
     const int count_j = cj->stars.count;
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
     const int gcount_i = ci->grav.count;
+#endif
     struct spart *restrict sparts_j = cj->stars.parts;
     struct part *restrict parts_i = ci->hydro.parts;
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
     struct gpart *restrict gparts_i = ci->grav.parts;
+#endif
 #if (FUNCTION_TASK_LOOP == TASK_LOOP_FEEDBACK)
     struct xpart *restrict xparts_i = ci->hydro.xparts;
 #endif
@@ -626,6 +634,7 @@ void DO_SYM_PAIR1_STARS(struct runner *r, struct cell *ci, struct cell *cj,
       const float pjy = spj->x[1] - cj->loc[1];
       const float pjz = spj->x[2] - cj->loc[2];
 
+#if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
       /* Only do DM vel. disp. loop if necessary for the model. */
       int sj_active_dm_loop = stars_dm_loop_is_active(spj, e);
       if (sj_active_dm_loop) {
@@ -640,9 +649,7 @@ void DO_SYM_PAIR1_STARS(struct runner *r, struct cell *ci, struct cell *cj,
             float dx[3] = {pjx - gix, pjy - giy, pjz - giz};
             const float r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
             if (r2 < hjg2) {
-  #if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
-              runner_iact_nonsym_feedback_dm_vel_mean(spj, gi, e->feedback_props);
-  #endif
+              runner_iact_nonsym_feedback_dm_vel_sum(spj, gi);
             }
           }
         }
@@ -657,13 +664,12 @@ void DO_SYM_PAIR1_STARS(struct runner *r, struct cell *ci, struct cell *cj,
             float dx[3] = {pjx - gix, pjy - giy, pjz - giz};
             const float r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
             if (r2 < hjg2) {
-  #if (FUNCTION_TASK_LOOP == TASK_LOOP_DENSITY)
-              runner_iact_nonsym_feedback_dm_vel_disp(spj, gi, e->feedback_props);
-  #endif
+              runner_iact_nonsym_feedback_dm_vel_disp(spj, gi);
             }
           }
         }
       }
+#endif
 
       /* Loop over the parts in ci. */
       for (int pid = count_i - 1; pid >= 0 && sort_i[pid].d > dj; pid--) {


### PR DESCRIPTION
Move the feedback data information around in the structure to prevent overwrite. Some renaming. These should merge automatically, just need to rename the accessor in the master branch. Now, dm_vel_disp_1d is in:

```
sp->feedback_data.dm_vel_disp_1d
```

(no longer in to_distribute)