### PR TITLE
fix: node index out of range error

### DIFF
--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -35,6 +35,7 @@
 
 /* Local headers. */
 #include "align.h"
+#include "config.h"
 
 // Type used for chunk bitmasks.
 typedef size_t hashmap_mask_t;


### PR DESCRIPTION
hashmap.h depends on WITH_FOF_GALAXIES, which is defined in config.h. config.h is never included in hashmap.c, so WITH_FOF_GALAXIES is undefined there. Other includes of hashmap.h DO have config.h, so they have WITH_FOF_GALAXIES. This results in the hashmap_value_t struct having different fields in hashmap.c vs other code (namely fof.c). Include config.h directly in hashmap.h to ensure WITH_FOF_GALAXIES is always present (when being used).